### PR TITLE
Added :bang_methods option to enable bang methods for each flag

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -163,6 +163,13 @@ on Spaceship:
   Spaceship#electrolytes=
   Spaceship#electrolytes_changed?
 
+Opionally, you can set the <tt>:bang_methods</tt> option to true to enable the bang methods:
+
+  Spaceship#electrolytes!
+  Spaceship#not_electrolytes!
+
+which respectively enables or disables the electrolytes flag.
+
 
 ===Generated named scopes
 

--- a/lib/flag_shih_tzu.rb
+++ b/lib/flag_shih_tzu.rb
@@ -77,6 +77,19 @@ module FlagShihTzu
           end
         EVAL
 
+        # Define bancg methods when requested
+        if flag_options[colmn][:bang_methods]
+          class_eval <<-EVAL
+            def #{flag_name}!
+              enable_flag(:#{flag_name}, '#{colmn}')
+            end
+
+            def not_#{flag_name}!
+              disable_flag(:#{flag_name}, '#{colmn}')
+            end
+          EVAL
+        end
+
         # Define the named scopes if the user wants them and AR supports it
         if flag_options[colmn][:named_scopes] && respond_to?(named_scope_method)
           class_eval <<-EVAL

--- a/test/flag_shih_tzu_test.rb
+++ b/test/flag_shih_tzu_test.rb
@@ -52,6 +52,13 @@ class SpaceshipWithBitOperatorQueryMode < ActiveRecord::Base
   has_flags(1 => :warpdrive, 2 => :shields, :flag_query_mode => :bit_operator)
 end
 
+class SpaceshipWithBangMethods < ActiveRecord::Base
+  self.table_name = 'spaceships'
+  include FlagShihTzu
+
+  has_flags(1 => :warpdrive, 2 => :shields, :bang_methods => true)
+end
+
 class SpaceCarrier < Spaceship
 end
 
@@ -537,5 +544,13 @@ class FlagShihTzuDerivedClassTest < Test::Unit::TestCase
       @spaceship.warpdrive = false_value
       assert !@spaceship.warpdrive
     end
+  end
+
+  def test_should_define_bang_methods
+    spaceship = SpaceshipWithBangMethods.new
+    spaceship.warpdrive!
+    assert spaceship.warpdrive
+    spaceship.not_warpdrive!
+    assert !spaceship.warpdrive
   end
 end


### PR DESCRIPTION
This change allows you to set `:bang_methods` option in `has_flags` that enables more sugar like:

```
spaceship = Spaceship.new
spaceship.warpdrive!   # spaceship.warpdrive = true
spaceship.not_shields! # spaceship.shields = false
```
