### PR TITLE
Fixes error in case of non-default column name

### DIFF
--- a/lib/flag_shih_tzu.rb
+++ b/lib/flag_shih_tzu.rb
@@ -149,7 +149,7 @@ module FlagShihTzu
       # returns an array of integers suitable for a SQL IN statement.
       def sql_in_for_flag(flag, colmn)
         val = flag_mapping[colmn][flag]
-        num = 2 ** flag_mapping[flag_options[colmn][:column]].length
+        num = 2 ** flag_mapping[colmn].length
         (1..num).select {|i| i & val == val}
       end
 


### PR DESCRIPTION
"error undefined method `length' for nil:NilClass"
In case of default :flag_query_mode (:in_list) and non-default :column options,
flag_options[colmn][:column] is a symbol, but flag_mapping has string keys.
Storing column name in flag_options[colmn][:column] is unuseful and it is duplication of colmn.
