### PR TITLE
fix a deprecation warning in rails4

### DIFF
--- a/lib/flag_shih_tzu.rb
+++ b/lib/flag_shih_tzu.rb
@@ -145,8 +145,8 @@ module FlagShihTzu
         # Define the named scopes if the user wants them and AR supports it
         if flag_options[colmn][:named_scopes] && respond_to?(named_scope_method)
           class_eval <<-EVAL
-            #{named_scope_method} :#{flag_name}, lambda { { :conditions => #{flag_name}_condition } }
-            #{named_scope_method} :not_#{flag_name}, lambda { { :conditions => not_#{flag_name}_condition } }
+            #{named_scope_method} :#{flag_name}, lambda { where(#{flag_name}_condition) }
+            #{named_scope_method} :not_#{flag_name}, lambda { where(not_#{flag_name}_condition) }
           EVAL
         end
       end
@@ -235,7 +235,7 @@ module FlagShihTzu
         num = 2 ** flag_mapping[flag_options[colmn][:column]].length
         (1..num).select {|i| i & val == val}
       end
-    
+
       def sql_set_for_flag(flag, colmn, enabled = true, custom_table_name = self.table_name)
         check_flag(flag, colmn)
         "#{colmn} = #{colmn} #{enabled ? "| " : "& ~" }#{flag_mapping[colmn][flag]}"


### PR DESCRIPTION
flag_shih_tzu works fine on rails 4 beta1 but there is that annoying deprecation warning about the  scope, This pull request fixes it.

```
DEPRECATION WARNING: Returning a hash from a #scope or #default_scope block 
is deprecated. Please return an actual scope object instead. 
E.g. scope :red, -> { where(color: 'red') } 
rather than scope :red, -> { { conditions: { color: 'red' } } }. 
(The scope was defined at (eval):1.).
```
