### PR TITLE
Allow non sequential flag numbers

### DIFF
--- a/lib/flag_shih_tzu.rb
+++ b/lib/flag_shih_tzu.rb
@@ -232,7 +232,7 @@ module FlagShihTzu
       # returns an array of integers suitable for a SQL IN statement.
       def sql_in_for_flag(flag, colmn)
         val = flag_mapping[colmn][flag]
-        num = 2 ** flag_mapping[flag_options[colmn][:column]].length
+        num = 2 * flag_mapping[flag_options[colmn][:column]].values.max
         (1..num).select {|i| i & val == val}
       end
     

--- a/test/flag_shih_tzu_test.rb
+++ b/test/flag_shih_tzu_test.rb
@@ -68,6 +68,14 @@ class SpaceshipWithBangMethods < ActiveRecord::Base
   has_flags(1 => :warpdrive, 2 => :shields, :bang_methods => true)
 end
 
+class SpaceshipWithMissingFlags < ActiveRecord::Base
+  self.table_name = 'spaceships'
+  include FlagShihTzu
+
+  has_flags 1 => :warpdrive,
+            3 => :electrolytes
+end
+
 class SpaceCarrier < Spaceship
 end
 
@@ -176,6 +184,11 @@ class FlagShihTzuClassMethodsTest < Test::Unit::TestCase
     assert_equal "(spaceships.flags in (4,5,6,7))", Spaceship.electrolytes_condition
   end
 
+  def test_should_define_a_sql_condition_method_for_flag_enabled_with_missing_flags
+    assert_equal "(spaceships.flags in (1,3,5,7))", SpaceshipWithMissingFlags.warpdrive_condition
+    assert_equal "(spaceships.flags in (4,5,6,7))", SpaceshipWithMissingFlags.electrolytes_condition
+  end
+
   def test_should_accept_a_table_alias_option_for_sql_condition_method
     assert_equal "(old_spaceships.flags in (1,3,5,7))", Spaceship.warpdrive_condition(:table_alias => 'old_spaceships')
   end
@@ -191,6 +204,11 @@ class FlagShihTzuClassMethodsTest < Test::Unit::TestCase
     assert_equal "(spaceships.flags not in (1,3,5,7))", Spaceship.not_warpdrive_condition
     assert_equal "(spaceships.flags not in (2,3,6,7))", Spaceship.not_shields_condition
     assert_equal "(spaceships.flags not in (4,5,6,7))", Spaceship.not_electrolytes_condition
+  end
+
+  def test_should_define_a_sql_condition_method_for_flag_not_enabled_with_missing_flags
+    assert_equal "(spaceships.flags not in (1,3,5,7))", SpaceshipWithMissingFlags.not_warpdrive_condition
+    assert_equal "(spaceships.flags not in (4,5,6,7))", SpaceshipWithMissingFlags.not_electrolytes_condition
   end
 
   def test_should_define_a_sql_condition_method_for_flag_enabled_with_custom_table_name


### PR DESCRIPTION
We had the problem that the generated condition wasn't correct any more after someone removed one of the flags for a model class that wasn't needed any more. We then had a gap in our flag numbers (1, 2, 4, 5, 6) and our queries didn't return what we expected.

From a purist's point of view I can understand that developers should be aware of the fact that you shouldn't just pick and match your flag numbers but stuff just happens and I prefer my gems being fault tolerant.
