### PR TITLE
Add flag_keys convenience method.

### DIFF
--- a/lib/flag_shih_tzu.rb
+++ b/lib/flag_shih_tzu.rb
@@ -173,6 +173,10 @@ module FlagShihTzu
       raise NoSuchFlagException.new("determine_flag_colmn_for: Couldn't determine column for your flags!")
     end
 
+    def flag_keys(colmn = DEFAULT_COLUMN_NAME)
+      flag_mapping[colmn].keys
+    end
+
     private
 
       def parse_options(*args)


### PR DESCRIPTION
`Foo.flag_keys` provides a more elegant way of accessing the keys used for the flags than `Foo.flag_mapping['flags'].keys` .
