### PR TITLE
Handle Rails 5 #tables deprecation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,8 @@ matrix:
       gemfile: gemfiles/Gemfile.activerecord-3.2.x
     - rvm: jruby-9.0.1.0
       gemfile: gemfiles/Gemfile.activerecord-4.0.x
+    - rvm: jruby-9.0.1.0
+      gemfile: gemfiles/Gemfile.activerecord-5.0.x
     - rvm: jruby-1.7.22
       gemfile: gemfiles/Gemfile.activerecord-2.3.x
     - rvm: jruby-1.7.22
@@ -43,6 +45,12 @@ matrix:
       gemfile: gemfiles/Gemfile.activerecord-3.2.x
     - rvm: jruby-1.7.22
       gemfile: gemfiles/Gemfile.activerecord-4.0.x
+    - rvm: jruby-1.7.22
+      gemfile: gemfiles/Gemfile.activerecord-4.1.x
+    - rvm: jruby-1.7.22
+      gemfile: gemfiles/Gemfile.activerecord-4.2.x
+    - rvm: jruby-1.7.22
+      gemfile: gemfiles/Gemfile.activerecord-5.0.x
     - rvm: 2.2.3
       gemfile: gemfiles/Gemfile.activerecord-2.3.x
     - rvm: 2.2.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ gemfile:
   - gemfiles/Gemfile.activerecord-4.0.x
   - gemfiles/Gemfile.activerecord-4.1.x
   - gemfiles/Gemfile.activerecord-4.2.x
+  - gemfiles/Gemfile.activerecord-5.0.x
 matrix:
   allow_failures:
     - rvm: ruby-head
@@ -58,10 +59,16 @@ matrix:
       gemfile: gemfiles/Gemfile.activerecord-3.0.x
     - rvm: 2.1.7
       gemfile: gemfiles/Gemfile.activerecord-3.1.x
+    - rvm: 2.1.7
+      gemfile: gemfiles/Gemfile.activerecord-5.0.x
     - rvm: 2.0.0
       gemfile: gemfiles/Gemfile.activerecord-2.3.x
     - rvm: 2.0.0
       gemfile: gemfiles/Gemfile.activerecord-4.2.x
+    - rvm: 2.0.0
+      gemfile: gemfiles/Gemfile.activerecord-5.0.x
+    - rvm: 1.9.3
+      gemfile: gemfiles/Gemfile.activerecord-5.0.x
     - rvm: 1.9.3
       gemfile: gemfiles/Gemfile.activerecord-4.2.x
     - rvm: 1.9.3

--- a/gemfiles/Gemfile.activerecord-5.0.x
+++ b/gemfiles/Gemfile.activerecord-5.0.x
@@ -1,0 +1,14 @@
+source "http://rubygems.org"
+
+gemspec :path => ".."
+
+gem "activerecord", "~> 5.0.0"
+gem "sqlite3", "~> 1.3", :platforms => [:ruby]
+gem "activerecord-jdbcsqlite3-adapter", :platforms => [:jruby]
+gem "activerecord-mysql2-adapter", :platforms => [:ruby]
+gem "activerecord-jdbcmysql-adapter", :platforms => [:jruby]
+gem "pg", :platforms => [:ruby_18]
+gem "activerecord-jdbcpostgresql-adapter", :platforms => [:jruby]
+
+gem "reek", "~> 3.5.0", :platforms => [:ruby]
+gem "roodi", "~> 5.0.0", :platforms => [:ruby]

--- a/lib/flag_shih_tzu.rb
+++ b/lib/flag_shih_tzu.rb
@@ -335,7 +335,12 @@ To turn off this warning set check_for_column: false in has_flags definition her
       has_ar = (!!defined?(ActiveRecord) && respond_to?(:descends_from_active_record?))
       # Supposedly Rails 2.3 takes care of this, but this precaution
       #   is needed for backwards compatibility
-      has_table = has_ar ? connection.tables.include?(custom_table_name) : true
+      has_table = if has_ar
+        sources = ::ActiveRecord::VERSION::MAJOR >= 5 ? connection.data_sources : connection.tables
+        sources.include?(custom_table_name)
+      else
+        true
+      end
       if has_table
         found_column = columns.detect { |column| column.name == colmn }
         # If you have not yet run the migration that adds the 'flags' column

--- a/lib/flag_shih_tzu.rb
+++ b/lib/flag_shih_tzu.rb
@@ -336,11 +336,14 @@ To turn off this warning set check_for_column: false in has_flags definition her
       # Supposedly Rails 2.3 takes care of this, but this precaution
       #   is needed for backwards compatibility
       has_table = if has_ar
-        sources = ::ActiveRecord::VERSION::MAJOR >= 5 ? connection.data_sources : connection.tables
-        sources.include?(custom_table_name)
-      else
-        true
-      end
+                    if ::ActiveRecord::VERSION::MAJOR >= 5
+                      connection.data_sources
+                    else
+                      connection.tables.include?(custom_table_name)
+                    end
+                  else
+                    true
+                  end
       if has_table
         found_column = columns.detect { |column| column.name == colmn }
         # If you have not yet run the migration that adds the 'flags' column
@@ -582,5 +585,4 @@ To turn off this warning set check_for_column: false in has_flags definition her
   def determine_flag_colmn_for(flag)
     self.class.determine_flag_colmn_for(flag)
   end
-
 end

--- a/test/flag_shih_tzu_test.rb
+++ b/test/flag_shih_tzu_test.rb
@@ -631,6 +631,8 @@ class FlagShihTzuClassMethodsTest < Test::Unit::TestCase
   def assert_where_value(expected, scope)
     actual = if ActiveRecord::VERSION::MAJOR == 2
                scope.proxy_options[:conditions]
+             elsif ActiveRecord::VERSION::MAJOR >= 5
+               scope.where_clause.ast.children.first.expr
              else
                scope.where_values.first
              end

--- a/test/schema.rb
+++ b/test/schema.rb
@@ -1,6 +1,5 @@
 ActiveRecord::Schema.define(:version => 0) do
   create_table :spaceships, :force => true do |t|
-    t.string :type, :null => false, :default => 'Spaceship'
     t.integer :flags, :null => false, :default => 0
     t.string :incorrect_flags_column, :null => false, :default => ''
   end


### PR DESCRIPTION
Similar to #57 , but keeps support for Rails < 5.0.

Added ActiveRecord 5 to the travis build... some tests are failing will check them out tomorrow.