### PR TITLE
Fix Ruby 2.4 warnings because of Fixnum

### DIFF
--- a/lib/flag_shih_tzu.rb
+++ b/lib/flag_shih_tzu.rb
@@ -318,7 +318,7 @@ To turn off this warning set check_for_column: false in has_flags definition her
                     else
                       options.
                       keys.
-                      select { |key| !key.is_a?(Fixnum) }.
+                      select { |key| !key.is_a?(Integer) }.
                       inject({}) do |hash, key|
                         hash[key] = options.delete(key)
                         hash


### PR DESCRIPTION
This PR fixes this warning:

```
/Users/juanito-fatas/.gem/ruby/2.4.0/gems/flag_shih_tzu-0.3.16/lib/flag_shih_tzu.rb:321: warning: constant ::Fixnum is deprecated
```

Ruby 2.4 unified Fixnum and Bignum into Integer.

https://www.ruby-lang.org/en/news/2016/12/25/ruby-2-4-0-released/