### PR TITLE
Ruby 2.4 unifies Bignum and Fixnum into Integer ..

### DIFF
--- a/lib/flag_shih_tzu.rb
+++ b/lib/flag_shih_tzu.rb
@@ -318,7 +318,7 @@ To turn off this warning set check_for_column: false in has_flags definition her
                     else
                       options.
                       keys.
-                      select { |key| !key.is_a?(Fixnum) }.
+                      select { |key| !key.is_a?(Integer) }.
                       inject({}) do |hash, key|
                         hash[key] = options.delete(key)
                         hash


### PR DESCRIPTION
Fixnum check now throws a deprecation warning in Ruby 2.4
warning: constant ::Fixnum is deprecated