### PR TITLE
fixed Rails5.1 DEPRECATION WARNING

### DIFF
--- a/lib/flag_shih_tzu.rb
+++ b/lib/flag_shih_tzu.rb
@@ -180,7 +180,8 @@ To turn off this warning set check_for_column: false in has_flags definition her
             end
           end
 
-          if ActiveRecord::VERSION::MAJOR >= 5 && ActiveRecord::VERSION::MINOR >= 1
+          if ActiveRecord::VERSION::MAJOR >= 5 &&
+              ActiveRecord::VERSION::MINOR >= 1
             class_eval <<-EVAL, __FILE__, __LINE__ + 1
               def #{flag_name}_saved_changed?
                 if colmn_changes = saved_changes["#{colmn}"]

--- a/lib/flag_shih_tzu.rb
+++ b/lib/flag_shih_tzu.rb
@@ -180,8 +180,7 @@ To turn off this warning set check_for_column: false in has_flags definition her
             end
           end
 
-          if ActiveRecord::VERSION::MAJOR >= 5 &&
-              ActiveRecord::VERSION::MINOR >= 1
+          if self.method_defined?(:saved_changes)
             class_eval <<-EVAL, __FILE__, __LINE__ + 1
               def #{flag_name}_saved_changed?
                 if colmn_changes = saved_changes["#{colmn}"]

--- a/lib/flag_shih_tzu.rb
+++ b/lib/flag_shih_tzu.rb
@@ -180,6 +180,18 @@ To turn off this warning set check_for_column: false in has_flags definition her
             end
           end
 
+          if ActiveRecord::VERSION::MAJOR >= 5 && ActiveRecord::VERSION::MINOR >= 1
+            class_eval <<-EVAL, __FILE__, __LINE__ + 1
+              def #{flag_name}_saved_changed?
+                if colmn_changes = saved_changes["#{colmn}"]
+                  flag_bit = self.class.flag_mapping["#{colmn}"][:#{flag_name}]
+                  (colmn_changes[0] & flag_bit) != (colmn_changes[1] & flag_bit)
+                else
+                  false
+                end
+              end
+            EVAL
+          end
         end
 
         if colmn != DEFAULT_COLUMN_NAME

--- a/lib/flag_shih_tzu.rb
+++ b/lib/flag_shih_tzu.rb
@@ -180,7 +180,7 @@ To turn off this warning set check_for_column: false in has_flags definition her
             end
           end
 
-          if self.method_defined?(:saved_changes)
+          if method_defined?(:saved_changes)
             class_eval <<-EVAL, __FILE__, __LINE__ + 1
               def #{flag_name}_saved_changed?
                 if colmn_changes = saved_changes["#{colmn}"]

--- a/lib/flag_shih_tzu.rb
+++ b/lib/flag_shih_tzu.rb
@@ -182,7 +182,7 @@ To turn off this warning set check_for_column: false in has_flags definition her
 
           if method_defined?(:saved_changes)
             class_eval <<-EVAL, __FILE__, __LINE__ + 1
-              def #{flag_name}_saved_changed?
+              def saved_change_to_#{flag_name}?
                 if colmn_changes = saved_changes["#{colmn}"]
                   flag_bit = self.class.flag_mapping["#{colmn}"][:#{flag_name}]
                   (colmn_changes[0] & flag_bit) != (colmn_changes[1] & flag_bit)


### PR DESCRIPTION
AR 5.1 after `save` use #changes is DEPRECATION WARNING Thus create new method `#saved_change_to_{flag_name}?`
https://github.com/rails/rails/blob/1c275d812f35f53f93cd96184a4f319983766cc5/activerecord/lib/active_record/attribute_methods/dirty.rb#L23-L24

```
DEPRECATION WARNING: The behavior of `changes` inside of after callbacks will be changing in the next version of Rails. The new return value will reflect the behavior of calling the method after `save` returned (e.g. the opposite of what it returns now). To maintain the current behavior, use `saved_changes` instead.
```