### PR TITLE
skip if `#has_flags` is called by running `rails db:create`

### DIFF
--- a/lib/flag_shih_tzu.rb
+++ b/lib/flag_shih_tzu.rb
@@ -22,10 +22,12 @@ module FlagShihTzu
 
   module ClassMethods
     def has_flags(*args)
-      begin
-        connection
-      rescue ActiveRecord::NoDatabaseError
-        return
+      if ActiveRecord::VERSION::STRING >= "4.1."
+        begin
+          connection
+        rescue ActiveRecord::NoDatabaseError
+          return
+        end
       end
 
       flag_hash, opts = parse_flag_options(*args)

--- a/lib/flag_shih_tzu.rb
+++ b/lib/flag_shih_tzu.rb
@@ -22,6 +22,12 @@ module FlagShihTzu
 
   module ClassMethods
     def has_flags(*args)
+      begin
+        connection
+      rescue ActiveRecord::NoDatabaseError
+        return
+      end
+
       flag_hash, opts = parse_flag_options(*args)
       opts =
         {


### PR DESCRIPTION
## What happened?
`rails db:create` fails with the following trace:
```
rails aborted!
ActiveRecord::NoDatabaseError: Unknown database 'myproject_development'
/app/myproject/vendor/bundle/ruby/2.5.0/gems/activerecord-5.2.0/lib/active_record/connection_adapters/mysql2_adapter.rb:26:in `rescue in mysql2_connection'
/app/myproject/vendor/bundle/ruby/2.5.0/gems/activerecord-5.2.0/lib/active_record/connection_adapters/mysql2_adapter.rb:12:in `mysql2_connection'
/app/myproject/vendor/bundle/ruby/2.5.0/gems/activerecord-5.2.0/lib/active_record/connection_adapters/abstract/connection_pool.rb:809:in `new_connection'
/app/myproject/vendor/bundle/ruby/2.5.0/gems/activerecord-5.2.0/lib/active_record/connection_adapters/abstract/connection_pool.rb:853:in `checkout_new_connection'
/app/myproject/vendor/bundle/ruby/2.5.0/gems/activerecord-5.2.0/lib/active_record/connection_adapters/abstract/connection_pool.rb:832:in `try_to_checkout_new_connection'
/app/myproject/vendor/bundle/ruby/2.5.0/gems/activerecord-5.2.0/lib/active_record/connection_adapters/abstract/connection_pool.rb:793:in `acquire_connection'
/app/myproject/vendor/bundle/ruby/2.5.0/gems/activerecord-5.2.0/lib/active_record/connection_adapters/abstract/connection_pool.rb:521:in `checkout'
/app/myproject/vendor/bundle/ruby/2.5.0/gems/activerecord-5.2.0/lib/active_record/connection_adapters/abstract/connection_pool.rb:380:in `connection'
/app/myproject/vendor/bundle/ruby/2.5.0/gems/activerecord-5.2.0/lib/active_record/connection_adapters/abstract/connection_pool.rb:1008:in `retrieve_connection'
/app/myproject/vendor/bundle/ruby/2.5.0/gems/activerecord-5.2.0/lib/active_record/connection_handling.rb:118:in `retrieve_connection'
/app/myproject/vendor/bundle/ruby/2.5.0/gems/activerecord-5.2.0/lib/active_record/connection_handling.rb:90:in `connection'
/app/myproject/vendor/bundle/ruby/2.5.0/gems/switch_point-0.8.0/lib/switch_point/model.rb:93:in `connection'
/app/myproject/vendor/bundle/ruby/2.5.0/bundler/gems/flag_shih_tzu-b07b5a721112/lib/flag_shih_tzu.rb:365:in `check_flag_column'
/app/myproject/vendor/bundle/ruby/2.5.0/bundler/gems/flag_shih_tzu-b07b5a721112/lib/flag_shih_tzu.rb:39:in `has_flags'
/app/myproject/app/models/product.rb:92:in `<class:Product>'
```
`#has_flags` is called in `/app/myproject/app/models/product.rb:92`.

## Envirinment
```
Ruby: 2.5.0
Rails: 5.2.0
```
## How to fix
Catch `ActiveRecord::NoDatabaseError` and do nothing. It fails when run `rails db:create` because `#connection` raises `ActiveRecord::NoDatabaseError`. 
It's not necessary to check what `has_flags` does if it's in database creation.