### PR TITLE
When #selected_flags= passed with nil it clears flag bits.

### DIFF
--- a/lib/flag_shih_tzu.rb
+++ b/lib/flag_shih_tzu.rb
@@ -224,6 +224,7 @@ To turn off this warning set check_for_column: false in has_flags definition her
             # useful for a form builder
             def selected_#{colmn}=(chosen_flags)
               unselect_all_flags("#{colmn}")
+              return if chosen_flags.nil?
               chosen_flags.each do |selected_flag|
                 enable_flag(selected_flag.to_sym, "#{colmn}") if selected_flag.present?
               end
@@ -514,6 +515,7 @@ To turn off this warning set check_for_column: false in has_flags definition her
   # use selected_#{column}= for custom column names.
   def selected_flags=(chosen_flags)
     unselect_all_flags
+    return if chosen_flags.nil?
     chosen_flags.each do |selected_flag|
       if selected_flag.present?
         enable_flag(selected_flag.to_sym, DEFAULT_COLUMN_NAME)

--- a/test/flag_shih_tzu_test.rb
+++ b/test/flag_shih_tzu_test.rb
@@ -846,6 +846,29 @@ class FlagShihTzuInstanceMethodsTest < Test::Unit::TestCase
     assert !@spaceship.has_flag?
   end
 
+  def test_should_define_a_selected_flags_writer_method
+    @spaceship.selected_flags = [:warpdrive]
+    assert @spaceship.warpdrive
+    assert !@spaceship.shields
+    assert !@spaceship.electrolytes
+
+    @spaceship.selected_flags = [:warpdrive, :shields, :electrolytes]
+    assert @spaceship.warpdrive
+    assert @spaceship.shields
+    assert @spaceship.electrolytes
+
+    @spaceship.selected_flags = []
+    assert !@spaceship.warpdrive
+    assert !@spaceship.shields
+    assert !@spaceship.electrolytes
+
+    @spaceship.selected_flags = [:warpdrive, :shields, :electrolytes]
+    @spaceship.selected_flags = nil
+    assert !@spaceship.warpdrive
+    assert !@spaceship.shields
+    assert !@spaceship.electrolytes
+  end
+
   # --------------------------------------------------
 
   def test_should_define_a_customized_all_flags_reader_method
@@ -899,6 +922,10 @@ class FlagShihTzuInstanceMethodsTest < Test::Unit::TestCase
     assert @small_spaceship.hyperspace
 
     @small_spaceship.selected_bits = []
+    assert !@small_spaceship.warpdrive
+    assert !@small_spaceship.hyperspace
+
+    @small_spaceship.selected_bits = nil
     assert !@small_spaceship.warpdrive
     assert !@small_spaceship.hyperspace
   end
@@ -1003,6 +1030,13 @@ class FlagShihTzuInstanceMethodsTest < Test::Unit::TestCase
 
     @big_spaceship.selected_bits = []
     @big_spaceship.selected_commanders = []
+    assert !@big_spaceship.warpdrive
+    assert !@big_spaceship.hyperspace
+    assert !@big_spaceship.jeanlucpicard
+    assert !@big_spaceship.dajanatroj
+
+    @big_spaceship.selected_bits = nil
+    @big_spaceship.selected_commanders = nil
     assert !@big_spaceship.warpdrive
     assert !@big_spaceship.hyperspace
     assert !@big_spaceship.jeanlucpicard


### PR DESCRIPTION
This would make `flag_shih_tzu` works with Rails which would convert empty array to `nil`.

See:

https://github.com/rails/rails/issues/13766
https://github.com/rails/rails/pull/13188