### PR TITLE
Avoid establishing a database connection unless necessary

### DIFF
--- a/lib/flag_shih_tzu.rb
+++ b/lib/flag_shih_tzu.rb
@@ -22,14 +22,6 @@ module FlagShihTzu
 
   module ClassMethods
     def has_flags(*args)
-      if ActiveRecord::VERSION::STRING >= "4.1."
-        begin
-          connection
-        rescue ActiveRecord::NoDatabaseError
-          return
-        end
-      end
-
       flag_hash, opts = parse_flag_options(*args)
       opts =
         {
@@ -404,6 +396,15 @@ To turn off this warning set check_for_column: false in has_flags definition her
       end
 
       true
+
+      # Quietly ignore NoDatabaseErrors - presumably we're being run during, eg, `rails db:create`.
+      # NoDatabaseError was only introduced in Rails 4.1, which is why this error-handling is a bit convoluted.
+    rescue StandardError => e
+      if defined?(ActiveRecord::NoDatabaseError) && e.is_a?(ActiveRecord::NoDatabaseError)
+        true
+      else
+        raise
+      end
     end
 
     def sql_condition_for_flag(flag, colmn, enabled = true, custom_table_name = table_name)

--- a/test/flag_shih_tzu_test.rb
+++ b/test/flag_shih_tzu_test.rb
@@ -1226,24 +1226,26 @@ class FlagShihTzuInstanceMethodsTest < Test::Unit::TestCase
     assert SpaceshipWithNonIntegerColumn3.method_defined?(:warpdrive)
   end
 
-  def test_should_ignore_database_missing_errors
-    assert_nothing_raised do
-      eval(<<-EOF
-        class SpaceshipWithoutDatabaseConnection < ActiveRecord::Base
-          def self.connection
-            raise ActiveRecord::NoDatabaseError.new("Unknown database")
-          end
-          self.table_name ="spaceships"
-          include FlagShihTzu
+  if ActiveRecord::VERSION::STRING >= "4.1."
+    def test_should_ignore_database_missing_errors
+      assert_nothing_raised do
+        eval(<<-EOF
+          class SpaceshipWithoutDatabaseConnection < ActiveRecord::Base
+            def self.connection
+              raise ActiveRecord::NoDatabaseError.new("Unknown database")
+            end
+            self.table_name ="spaceships"
+            include FlagShihTzu
 
-          has_flags 1 => :warpdrive,
-                    2 => :shields,
-                    3 => :electrolytes
-        end
-      EOF
-      )
+            has_flags 1 => :warpdrive,
+                      2 => :shields,
+                      3 => :electrolytes
+          end
+        EOF
+        )
+      end
+      assert SpaceshipWithoutDatabaseConnection.method_defined?(:warpdrive)
     end
-    assert SpaceshipWithoutDatabaseConnection.method_defined?(:warpdrive)
   end
 
   def test_shouldnt_establish_a_connection_if_check_for_column_is_false


### PR DESCRIPTION
It used to be possible to avoid establishing a database connection when calling `has_flags({...}, check_for_column: false)`, but since #74 `has_flags()` always tries to connect.

How about this, which moves the `rescue ActiveRecord::NoDatabaseError` into the `check_flag_column` method?