### PR TITLE
Add table_alias option to sql not-condition methods

### DIFF
--- a/lib/flag_shih_tzu.rb
+++ b/lib/flag_shih_tzu.rb
@@ -124,8 +124,13 @@ To turn off this warning set check_for_column: false in has_flags definition her
               )
             end
 
-            def self.not_#{flag_name}_condition
-              sql_condition_for_flag(:#{flag_name}, "#{colmn}", false)
+            def self.not_#{flag_name}_condition(options = {})
+              sql_condition_for_flag(
+                :#{flag_name},
+                "#{colmn}",
+                false,
+                options[:table_alias] || table_name
+              )
             end
 
             def self.set_#{flag_name}_sql

--- a/test/flag_shih_tzu_test.rb
+++ b/test/flag_shih_tzu_test.rb
@@ -316,6 +316,11 @@ class FlagShihTzuClassMethodsTest < Test::Unit::TestCase
                  SpaceshipWithMissingFlags.not_electrolytes_condition
   end
 
+  def test_should_accept_a_table_alias_option_for_not_sql_condition_method
+    assert_equal '("old_spaceships"."flags" not in (1,3,5,7))',
+                 Spaceship.not_warpdrive_condition(table_alias: "old_spaceships")
+  end
+
   def test_sql_condition_for_flag_with_custom_table_name_and_default_query_mode
     assert_equal '("custom_spaceships"."flags" in (1,3,5,7))',
                  Spaceship.send(:sql_condition_for_flag,


### PR DESCRIPTION
This brings the `self.not_#{flag_name}_condition` methods in line with the `self.#{flag_name}_condition` methods.